### PR TITLE
Enabled setting cookie through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ const ytstream = require('yt-stream');
 ```
 
 ## Setting a cookie
-You can easily set a cookie by changing the `cookie` property to the YouTube cookie.
+You can easily set a cookie by changing the `cookie` property to the YouTube cookie. It is also possible to set the cookie using the environment variable `YT_COOKIE`. If both are set the programmatically set one will be used.
+
+The cookie is required to download videos that are age restricted.
 ```js
 const ytstream = require('yt-stream');
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,15 @@ class YTStream{
     this.search = function(...args){
       return search(this, ...args);
     }
-    this.cookie = null;
 		this.userAgent = null;
+  }
+
+  get cookie(){
+    return this.storedCookie || process.env.YT_COOKIE;
+  }
+
+  set cookie(newCookie){
+    this.storedCookie = newCookie;
   }
 }
 


### PR DESCRIPTION
Congratulations on the library, it is very useful!

I'm also using [DiscordAudio](https://github.com/Luuk-Dev/DiscordAudio) and need to set the cookie to be able to play age restricted videos.
I read this [issue](https://github.com/Luuk-Dev/DiscordAudio/issues/3) and it seems to work fine, but it is not as easy use as the rest of the library.
So to solve this I propose using a environment variable to be able to set the cookie. I tried to keep the code backwards compatible. What do you think of it?
I also intent to submit a PR to DiscordAudio to set the cookie using a property.

